### PR TITLE
Updated Dockerfile to manim7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM manimcommunity/manim:v0.6.0
+FROM manimcommunity/manim:v0.7.0
 
 COPY --chown=manimuser:manimuser . /manim

--- a/basic_example_scenes.ipynb
+++ b/basic_example_scenes.ipynb
@@ -142,7 +142,7 @@
     "        VGroup(title, basel).arrange(DOWN)\n",
     "        self.play(\n",
     "            Write(title),\n",
-    "            FadeInFrom(basel, UP),\n",
+    "            FadeIn(basel, shift = UP),\n",
     "        )\n",
     "        self.wait()\n",
     "\n",
@@ -150,11 +150,11 @@
     "        transform_title.to_corner(UP + LEFT)\n",
     "        self.play(\n",
     "            Transform(title, transform_title),\n",
-    "            LaggedStart(*[FadeOutAndShift(obj, direction=DOWN) for obj in basel]),\n",
+    "            LaggedStart(*[FadeOut(obj, shift=DOWN) for obj in basel]),\n",
     "        )\n",
     "        self.wait()\n",
     "\n",
-    "        grid = NumberPlane()\n",
+    "        grid = NumberPlane(x_range=(- 10, 10, 1), y_range=(- 6.0, 6.0, 1))\n",
     "        grid_title = Tex(\"This is a grid\")\n",
     "        grid_title.scale(1.5)\n",
     "        grid_title.move_to(transform_title)\n",
@@ -162,7 +162,7 @@
     "        self.add(grid, grid_title)  # Make sure title is on top of grid\n",
     "        self.play(\n",
     "            FadeOut(title),\n",
-    "            FadeInFrom(grid_title, direction=DOWN),\n",
+    "            FadeIn(grid_title, shift=DOWN),\n",
     "            Create(grid, run_time=3, lag_ratio=0.1),\n",
     "        )\n",
     "        self.wait()\n",
@@ -201,9 +201,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "manim6",
+   "display_name": "manim7",
    "language": "python",
-   "name": "manim6"
+   "name": "manim7"
   },
   "language_info": {
    "codemirror_mode": {
@@ -215,7 +215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The examples were also adjusted to have no errors or warnings. Increased the size of the number plane to make the transformed plane extend out of the frame.

The associated mybinder page should be like this:
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/PaulCMurdoch/jupyter_examples/update7.0?filepath=basic_example_scenes.ipynb)