### PR TITLE
Update Jupyter Examples to Manim 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM manimcommunity/manim:v0.7.0
+FROM manimcommunity/manim:v0.8.0
 
 COPY --chown=manimuser:manimuser . /manim


### PR DESCRIPTION
Updating Jupyter Examples to Manim 8. Only the docker file was changed as the code compiled without error or warning.
The mybinder page will look like [this](https://mybinder.org/v2/gh/PaulCMurdoch/jupyter_examples/001d77557539dcc96eeaa55ab32c8a8357188be7).