### PR TITLE
first suggestion for v0.11.0 release tour

### DIFF
--- a/v0.11.0 Release Tour.ipynb
+++ b/v0.11.0 Release Tour.ipynb
@@ -1,0 +1,189 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "virtual-consumer",
+   "metadata": {},
+   "source": [
+    "## Manim v0.11.0 Release Tour\n",
+    "\n",
+    "This interactive worksheet contains an overview over the new features contained in the latest release of the community maintained version of Manim."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "central-quantity",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from manim import *\n",
+    "\n",
+    "config.media_width = \"80%\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mexican-texas",
+   "metadata": {},
+   "source": [
+    "### [#2075](https://github.com/ManimCommunity/manim/pull/2075): New method: `Mobject.set_default` for changing default values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "everyday-shade",
+   "metadata": {},
+   "source": [
+    "With the new `set_default` method it is easy to change default arguments for mobjects. For example, `Text.set_default(color=RED)` changes the default color of `Text` to red:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "multiple-tenant",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%manim -qm -v WARNING ChangedDefaultDemo\n",
+    "\n",
+    "class ChangedDefaultDemo(Scene):\n",
+    "    def construct(self):\n",
+    "        Text.set_default(color=RED)\n",
+    "        t = Text(\"This is red text, magic!\")\n",
+    "        \n",
+    "        # You can also change multiple arguments at once:\n",
+    "        Circle.set_default(color=WHITE, fill_opacity=0.5)\n",
+    "        c = Circle().next_to(t, DOWN)\n",
+    "        VGroup(t, c).center()\n",
+    "        \n",
+    "        self.add(t, c)\n",
+    "\n",
+    "        # Call the method without arguments to restore the default behavior!\n",
+    "        Text.set_default()\n",
+    "        Circle.set_default()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "hourly-aerospace",
+   "metadata": {},
+   "source": [
+    "\n",
+    "### [#1991](https://github.com/ManimCommunity/manim/pull/1991): Added support for boolean operations on `VMobject`s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "super-doubt",
+   "metadata": {},
+   "source": [
+    "Manim can now compute the union, intersection, and difference of mobjects!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "tutorial-receptor",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%manim -qm -v WARNING BooleanOperationDemo\n",
+    "\n",
+    "class BooleanOperationDemo(Scene):\n",
+    "    def construct(self):\n",
+    "        c1 = Circle(radius=2, fill_opacity=0.5, color=YELLOW).shift(LEFT)\n",
+    "        c2 = Circle(radius=2, fill_opacity=0.5, color=BLUE).shift(RIGHT)\n",
+    "        circles = VGroup(c1, c2)\n",
+    "        self.add(circles.scale(0.5))\n",
+    "        grid = VGroup(\n",
+    "            Union(c1, c2, color=GREEN, fill_opacity=0.5),\n",
+    "            Intersection(c1, c2, color=GREEN, fill_opacity=0.5),\n",
+    "            Difference(c1, c2, color=GREEN, fill_opacity=0.5),\n",
+    "            Exclusion(c1, c2, color=GREEN, fill_opacity=0.5)\n",
+    "        ).arrange_in_grid(2, 2, buff=3)\n",
+    "        self.add(grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "shaped-decimal",
+   "metadata": {},
+   "source": [
+    "### [#2118](https://github.com/ManimCommunity/manim/pull/2118): Added 3D support for `ArrowVectorField` and `StreamLines`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "younger-latex",
+   "metadata": {},
+   "source": [
+    "When passing a `z_range` parameter to `ArrowVectorField` or `StreamLines`, the vector field will be rendered in three dimensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dedicated-market",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%manim -qm -v WARNING --disable_caching ThreeDArrowVectorField\n",
+    "\n",
+    "class ThreeDArrowVectorField(ThreeDScene):\n",
+    "    def construct(self):\n",
+    "\n",
+    "        def func(p):\n",
+    "            return np.cross(p, np.array([0, 0, p[2]]))\n",
+    "\n",
+    "        vector_field = ArrowVectorField(\n",
+    "            func,\n",
+    "            x_range=[-2.5, 2.5, 1],\n",
+    "            y_range=[-2.5, 2.5, 1],\n",
+    "            z_range=[-1.5, 1.5, 1],\n",
+    "        )\n",
+    "        particle = Dot3D(OUT + RIGHT * 2)\n",
+    "        self.add(vector_field, particle)\n",
+    "        particle.add_updater(vector_field.get_nudge_updater(2))\n",
+    "        self.move_camera(PI/3, -PI/4, run_time=3)\n",
+    "        stream_lines = StreamLines(\n",
+    "            func,\n",
+    "            x_range=[-2.5, 2.5, 1.5],\n",
+    "            y_range=[-2.5, 2.5, 1.5],\n",
+    "            z_range=[-1.5, 1.5, 1.5],\n",
+    "        )\n",
+    "        self.play(Transform(vector_field, stream_lines), run_time=0.5)\n",
+    "        self.wait()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "metric-denial",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/v0.11.0 Release Tour.ipynb
+++ b/v0.11.0 Release Tour.ipynb
@@ -66,18 +66,50 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hourly-aerospace",
+   "id": "dependent-cookie",
    "metadata": {},
    "source": [
     "\n",
-    "### [#1991](https://github.com/ManimCommunity/manim/pull/1991): Added support for boolean operations on `VMobject`s"
+    "### [#2094](https://github.com/ManimCommunity/manim/pull/2094): Implicit function plotting\n",
+    "\n",
+    "There is now a new Mobject allowing to plot points that satisfy some equation. Here is an example for the curves defined by $xy^2 - x^2y - 2 = 0$ (yellow) and $x^3 - x + 1 - y^2 = 0$ (red)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "portuguese-barrier",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%manim -qm -v WARNING ImplicitFunctionDemo\n",
+    "\n",
+    "class ImplicitFunctionDemo(Scene):\n",
+    "    def construct(self):\n",
+    "        plane = NumberPlane()\n",
+    "        curve = ImplicitFunction(\n",
+    "            lambda x, y: x * y**2 - x**2 * y - 2,\n",
+    "            color=YELLOW,\n",
+    "        )\n",
+    "        self.add(plane)\n",
+    "        self.play(Create(curve))\n",
+    "        self.wait()\n",
+    "        elliptic_curve = ImplicitFunction(\n",
+    "            lambda x, y: x**3 - x + 1 - y**2,\n",
+    "            color=RED,\n",
+    "        )\n",
+    "        self.play(Create(elliptic_curve))\n",
+    "        self.wait()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "super-doubt",
+   "id": "hourly-aerospace",
    "metadata": {},
    "source": [
+    "\n",
+    "### [#1991](https://github.com/ManimCommunity/manim/pull/1991): Added support for boolean operations on `VMobject`s\n",
+    "\n",
     "Manim can now compute the union, intersection, and difference of mobjects!"
    ]
   },
@@ -157,9 +189,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "agricultural-charm",
+   "metadata": {},
+   "source": [
+    "To find out more about the exciting new features, fixed bugs, deprecated functions, and other improvements made in Manim v0.11.0, check out the full changelog at <https://docs.manim.community/en/stable/changelog/0.11.0-changelog.html>. Enjoy *manimating*!"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "metric-denial",
+   "id": "funny-visiting",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/v0.11.0 Release Tour.ipynb
+++ b/v0.11.0 Release Tour.ipynb
@@ -49,13 +49,13 @@
     "\n",
     "class ChangedDefaultDemo(Scene):\n",
     "    def construct(self):\n",
-    "        Text.set_default(color=RED)\n",
-    "        t = Text(\"This is red text, magic!\")\n",
+    "        Text.set_default(color=BLUE)\n",
+    "        t = Text(\"This is blue text, magic!\")\n",
     "        \n",
     "        # You can also change multiple arguments at once:\n",
-    "        Circle.set_default(color=WHITE, fill_opacity=0.5)\n",
-    "        c = Circle().next_to(t, DOWN)\n",
-    "        VGroup(t, c).center()\n",
+    "        Circle.set_default(color=GREEN, fill_opacity=0.5)\n",
+    "        c = Circle()\n",
+    "        VGroup(t, c).arrange(DOWN)\n",
     "        \n",
     "        self.add(t, c)\n",
     "\n",
@@ -66,30 +66,43 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dependent-cookie",
+   "id": "bearing-album",
    "metadata": {},
    "source": [
     "\n",
     "### [#2094](https://github.com/ManimCommunity/manim/pull/2094): Implicit function plotting\n",
     "\n",
-    "There is now a new Mobject allowing to plot points that satisfy some equation. Here is an example for the curves defined by $xy^2 - x^2y - 2 = 0$ (yellow) and $x^3 - x + 1 - y^2 = 0$ (red)."
+    "There is now a new Mobject allowing to plot points that satisfy some equation. Here is an example for the curves defined by $(x^2 + y^2)^2 - 42 (x^2 - y^2) = 0$ (yellow) and $x^3 - x + 1 - y^2 = 0$ (red)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "portuguese-barrier",
+   "id": "determined-weight",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ImplicitFunction?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "grateful-vancouver",
    "metadata": {},
    "outputs": [],
    "source": [
     "%%manim -qm -v WARNING ImplicitFunctionDemo\n",
     "\n",
+    "import numpy as np\n",
+    "\n",
     "class ImplicitFunctionDemo(Scene):\n",
     "    def construct(self):\n",
     "        plane = NumberPlane()\n",
     "        curve = ImplicitFunction(\n",
-    "            lambda x, y: x * y**2 - x**2 * y - 2,\n",
+    "            lambda x, y: (x**2 + y**2)**2 - 42*(x**2 - y**2),\n",
     "            color=YELLOW,\n",
+    "            max_quads=2000,\n",
     "        )\n",
     "        self.add(plane)\n",
     "        self.play(Create(curve))\n",
@@ -124,17 +137,26 @@
     "\n",
     "class BooleanOperationDemo(Scene):\n",
     "    def construct(self):\n",
-    "        c1 = Circle(radius=2, fill_opacity=0.5, color=YELLOW).shift(LEFT)\n",
-    "        c2 = Circle(radius=2, fill_opacity=0.5, color=BLUE).shift(RIGHT)\n",
+    "        VMobject.set_default(color=GREEN, fill_opacity=0.5)\n",
+    "        Circle.set_default(radius=2, fill_opacity=0.5)\n",
+    "        \n",
+    "        c1 = Circle(color=YELLOW).shift(LEFT)\n",
+    "        c2 = Circle(color=BLUE).shift(RIGHT)\n",
     "        circles = VGroup(c1, c2)\n",
     "        self.add(circles.scale(0.5))\n",
-    "        grid = VGroup(\n",
-    "            Union(c1, c2, color=GREEN, fill_opacity=0.5),\n",
-    "            Intersection(c1, c2, color=GREEN, fill_opacity=0.5),\n",
-    "            Difference(c1, c2, color=GREEN, fill_opacity=0.5),\n",
-    "            Exclusion(c1, c2, color=GREEN, fill_opacity=0.5)\n",
+    "        \n",
+    "        # Note: changing the default color and fill opacity for VMobject also affects subclasses\n",
+    "        # like Union, Intersection, Difference, and Exclusion.\n",
+    "        grid = VGroup(  \n",
+    "            Union(c1, c2),\n",
+    "            Intersection(c1, c2),\n",
+    "            Difference(c1, c2),\n",
+    "            Exclusion(c1, c2)\n",
     "        ).arrange_in_grid(2, 2, buff=3)\n",
-    "        self.add(grid)"
+    "        self.add(grid)\n",
+    "        \n",
+    "        VMobject.set_default()\n",
+    "        Circle.set_default()"
    ]
   },
   {
@@ -150,7 +172,7 @@
    "id": "younger-latex",
    "metadata": {},
    "source": [
-    "When passing a `z_range` parameter to `ArrowVectorField` or `StreamLines`, the vector field will be rendered in three dimensions."
+    "When passing a `z_range` parameter to `ArrowVectorField` or `StreamLines`, the vector field will be rendered in three dimensions. **Note:** this example takes a bit longer to render."
    ]
   },
   {
@@ -184,13 +206,13 @@
     "            y_range=[-2.5, 2.5, 1.5],\n",
     "            z_range=[-1.5, 1.5, 1.5],\n",
     "        )\n",
-    "        self.play(Transform(vector_field, stream_lines), run_time=0.5)\n",
+    "        self.play(FadeTransform(vector_field, stream_lines), run_time=0.5)\n",
     "        self.wait()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "agricultural-charm",
+   "id": "transparent-mount",
    "metadata": {},
    "source": [
     "To find out more about the exciting new features, fixed bugs, deprecated functions, and other improvements made in Manim v0.11.0, check out the full changelog at <https://docs.manim.community/en/stable/changelog/0.11.0-changelog.html>. Enjoy *manimating*!"
@@ -199,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "funny-visiting",
+   "id": "spatial-adventure",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
This is a first suggestion for a short release tour demonstrating new features of v0.11.0.

Improvements are welcome. Unfortunately, the notebook can only be tested locally at the moment and not yet via binder.

As soon as this is merged, I'd also add a new redirect from `https://try.manim.community/v0.11.0` to the corresponding binder worksheet.