### PR TITLE
update try.manim.community to v0.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM manimcommunity/manim:v0.13.1
+FROM manimcommunity/manim:v0.14.0
 
 COPY --chown=manimuser:manimuser . /manim


### PR DESCRIPTION
I just noticed that `try.manim.community` still uses an old version, so bumping it to `v0.14.0`
Did we forget to update this?