### PR TITLE
fix spelling: "LaTex" → "LaTeX"

### DIFF
--- a/First Steps with Manim.ipynb
+++ b/First Steps with Manim.ipynb
@@ -341,7 +341,7 @@
    "id": "potential-crowd",
    "metadata": {},
    "source": [
-    "As this example demonstrates, `MathTex` allows to render simple (math mode) LaTeX strings. If you want to render \"normal mode\" LaTex, use `Tex` instead.\n",
+    "As this example demonstrates, `MathTex` allows to render simple (math mode) LaTeX strings. If you want to render \"normal mode\" LaTeX, use `Tex` instead.\n",
     "\n",
     "Of course, Manim can also help you to visualize transformations of typeset formulae. Consider the following example:"
    ]


### PR DESCRIPTION
(with a capital "X")